### PR TITLE
[FIX] consuming from queue

### DIFF
--- a/pokeball/pub.py
+++ b/pokeball/pub.py
@@ -17,3 +17,5 @@ def get_message_sender(host='localhost', exchange='default', exchange_type='fano
         )
 
     return send_message
+
+send_message = get_message_sender()


### PR DESCRIPTION
- Rename message_pub and message_sub to pub and sub respectively
- Add a direct function `send_message` to make publishing simpler
- Fixes in specific queue consumers
